### PR TITLE
fix: handle null values in preg_match calls for PHP 8+ compatibility

### DIFF
--- a/component/Hatter/Hatter.php
+++ b/component/Hatter/Hatter.php
@@ -67,7 +67,7 @@ class Hatter implements ArrayAccess
         foreach ($this->tables as $table) {
             foreach ($table->getRows() as $row) {
                 foreach ($row->getValues() as $key => $value) {
-                    if (preg_match('/\{\{(.*)\}\}/', $value, $matches)) {
+                    if ($value !== null && preg_match('/\{\{(.*)\}\}/', $value, $matches)) {
                         $expression = trim($matches[1]);
                         $values = [
                             'faker' => $faker,
@@ -78,7 +78,7 @@ class Hatter implements ArrayAccess
                     }
 
                     // match values like `@user.alice.id` capturing `user`, `alice` and `id`
-                    if (preg_match('/@([a-z0-9_-]+)\.([a-z0-9_-]+)\.([a-z0-9_-]+)/', $value, $matches)) {
+                    if ($value !== null && preg_match('/@([a-z0-9_-]+)\.([a-z0-9_-]+)\.([a-z0-9_-]+)/', $value, $matches)) {
                         $refTable = $this->getTable($matches[1]);
                         $refRow = $refTable->getRow($matches[2]);
                         $value = $refRow->getValue($matches[3]);


### PR DESCRIPTION
- Add null checks before preg_match() calls in Hatter::postProcess()
- Prevents deprecation warnings when Row::getValue() returns null
- Maintains functionality while ensuring PHP 8+ compatibility

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

If this relates to a card, please include a link to the card here. Additionally, please terminate the PR title with `#` and the card number, such as `Fix doomsday bug #1234` -->

<!-- Please indicate if your PR introduces a breaking change -->
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [X] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [X] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
