### PR TITLE
feat: support escaped expressions

### DIFF
--- a/component/Hatter/Hatter.php
+++ b/component/Hatter/Hatter.php
@@ -67,6 +67,13 @@ class Hatter implements ArrayAccess
         foreach ($this->tables as $table) {
             foreach ($table->getRows() as $row) {
                 foreach ($row->getValues() as $key => $value) {
+                    // Handle escaped expressions: \{{name}} → {{name}}
+                    if ($value !== null && preg_match('/\\\\\{\{/', (string)$value)) {
+                        $value = preg_replace('/\\\\\{\{(.*?)\}\}/', '{{$1}}', (string)$value);
+                        $row->setValue($key, $value);
+                        continue;
+                    }
+
                     if ($value !== null && preg_match('/\{\{(.*)\}\}/', $value, $matches)) {
                         $expression = trim($matches[1]);
                         $values = [


### PR DESCRIPTION
## Proposed changes

Hatter uses `{{ }}` for expression evaluation (e.g., `{{ faker.lastName() }}`). However, some use cases require outputting literal `{{ }}` in fixture data - for example when fixtures contain template strings that use the same syntax for variable substitution at runtime.

Currently, there is no way to output literal `{{ }}` in a Hatter fixture. Any `{{content}}` is interpreted as an expression and evaluated.

This PR adds support for backslash escaping: `\{{name}}` outputs literal `{{name}}` without evaluation.

## Usage Example

```yaml
  tables:
    email_templates:
      rows:
        welcome:
          subject: "Welcome \{{username}}"
          body: "Hello \{{name}}, your account is ready."
```

**Backward Compatibility**

The backslash escape is new syntax that was previously invalid (would have caused an expression evaluation error), so no existing fixtures are affected.

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [X] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [X] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
